### PR TITLE
Fix OTP cooldown functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,9 @@ package-lock.json
 
 prisma/migrations
 src/generated
+
+.github
+.agent
+.specify
+.vscode
+specs"docs/inventory.md" 

--- a/package.json
+++ b/package.json
@@ -46,10 +46,8 @@
     "@prisma/adapter-pg": "^7.4.0",
     "@prisma/client": "^7.4.0",
     "@socket.io/redis-adapter": "^8.3.0",
-    "axios": "^1.13.5",
     "cloudinary": "^2.9.0",
     "cors": "^2.8.6",
-    "datauri": "^4.1.0",
     "dotenv": "^17.2.4",
     "express": "^5.2.1",
     "express-rate-limit": "^8.2.1",
@@ -72,14 +70,12 @@
     "@types/jsonwebtoken": "^9.0.10",
     "@types/multer": "^2.1.0",
     "@types/node": "^25.5.0",
-    "@types/pg": "^8.11.6",
     "@types/swagger-jsdoc": "^6.0.4",
     "@types/swagger-ui-express": "^4.1.8",
     "@typescript-eslint/eslint-plugin": "^8.57.1",
     "@typescript-eslint/parser": "^8.57.1",
     "@vitest/coverage-v8": "^4.1.0",
     "eslint": "^10.1.0",
-    "globals": "^17.3.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.4.0",
     "prettier": "^3.8.1",
@@ -87,7 +83,6 @@
     "supertest": "^6.3.4",
     "tsx": "^4.21.0",
     "typescript": "^5.6.0",
-    "vitest": "^4.1.0",
-    "zod-prisma-types": "3.3.11"
+    "vitest": "^4.1.0"
   }
 }

--- a/src/controllers/AuthController.ts
+++ b/src/controllers/AuthController.ts
@@ -17,9 +17,9 @@ export const requestOTP = asyncHandler(async (req, res) => {
   const { method, phoneNumber } = req.body;
   const deviceId = req.deviceId;
 
-  await authService.requestOTP(phoneNumber, method);
-
   const { cooldown } = await rateLimitService.incrementSend(phoneNumber, method, deviceId);
+
+  await authService.requestOTP(phoneNumber, method);
 
   new SuccessResponse('OTP sent successfully', { phoneNumber, method, cooldown }, 200).send(res);
 });

--- a/src/services/AuthService.ts
+++ b/src/services/AuthService.ts
@@ -306,6 +306,19 @@ export default class AuthService extends Service {
   }> {
     // in production -> Invalid or expired OTP only
 
+    const currentAttempts = await this.rateLimitCache.getVerifyAttempts(phoneNumber, method);
+    if (currentAttempts >= MAX_VERIFY_ATTEMPTS) {
+      throw new AppError(
+        'Maximum verification attempts reached',
+        400,
+        new OTPErrorDetails({
+          type: 'FAILED_ATTEMPT',
+          remainingAttempts: 0,
+          requestNewOtp: true,
+        })
+      );
+    }
+
     try {
       const hashedOTP = hashOTP(OTP);
 


### PR DESCRIPTION
## Fix: OTP Rate Limit Security Vulnerabilities

### Changes
- Move `rateLimitService.incrementSend()` to execute **before** OTP generation and dispatch in `AuthController.ts`, preventing SMS credit drain via endpoint spam
- Add pre-flight attempt check at the top of `AuthService.verifyOTP()` to block requests when `MAX_VERIFY_ATTEMPTS` is already reached
- delete unused packages

### Security Impact
- Closes rate limit bypass on Send OTP endpoint
- Closes verify attempt bypass on Verify OTP endpoint



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OTP verification to provide immediate feedback when maximum verification attempts are reached, preventing unnecessary processing.

* **Chores**
  * Removed unused dependencies from the project.
  * Updated configuration and ignore patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->